### PR TITLE
Mark usage of temporary files in `cmd`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Bemlint(NodeLinter):
     """Provides an interface to bemlint."""
 
     name = 'bemlint'
-    cmd = 'bemlint @ ${args}'
+    cmd = 'bemlint ${temp_file} ${args}'
     config_file = ('--config', '.bemlint.json')
     regex = (
         r'^.+?: line (?P<line>\d+), col (?P<col>\d+), '


### PR DESCRIPTION
The marker `@` was ambiguous in SublimeLinter.  Its usage has been deprecated in favor of explicit markers like `$temp_file`.